### PR TITLE
Kubernetes 1.20.15 and vagrant box memory tweak and metal for virtual loadbalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ sh destroy.sh
 1. [Kubeadm install](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
 1. [Kubernetes](https://github.com/kubernetes/kubernetes)
 1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
+1. [MetalLB](https://github.com/metallb/metallb)
 
 ## Troubleshooting
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,10 @@
 BOX_IMAGE = "ubuntu/xenial64"
 WORKER_COUNT = nil
 NETWORKING_TYPE = nil
-KUBERNETES_VERSION = '1.19.13'
+KUBERNETES_VERSION = '1.20.10'
 GO_VERSION = '1.15'
 DOCKER_VERSION = '19.03'
-CRICTL_VERSION = '1.18.0'
+CRICTL_VERSION = '1.20.0'
 METRICS_SERVER_VERSION = '0.3.7'
 
 if WORKER_COUNT.nil?
@@ -281,6 +281,9 @@ WORKERSCRIPT
 
 Vagrant.configure("2") do |config|
 
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1750"
+  end
   config.vm.define "master" do |master|
     master.vm.box = BOX_IMAGE
     master.vm.hostname = "master"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,11 +5,12 @@
 BOX_IMAGE = "ubuntu/xenial64"
 WORKER_COUNT = nil
 NETWORKING_TYPE = nil
-KUBERNETES_VERSION = '1.20.10'
+KUBERNETES_VERSION = '1.20.15'
 GO_VERSION = '1.15'
 DOCKER_VERSION = '19.03'
 CRICTL_VERSION = '1.20.0'
 METRICS_SERVER_VERSION = '0.3.7'
+METALLB_VERSION = '0.10.2'
 
 if WORKER_COUNT.nil?
   NODE_COUNT = 2
@@ -143,6 +144,8 @@ export IPADDR=$(ifconfig ${NET_INTERFACE} | grep Mask | awk '{ print $2 }' | cut
 export NODENAME=$(hostname -s)
 export NETWORKING=$1
 export METRICS_SERVER=$2
+export METALLB_VER=$3
+
 echo This VM has IP address $IPADDR and name $NODENAME
 echo "$IPADDR  $NODENAME" >> /etc/hosts
 echo "$IPADDR  $NODENAME.local" >> /etc/hosts
@@ -232,6 +235,20 @@ fi
 echo 'Deploying metrics-server...'
 kubectl create -f components.yaml > /dev/null 2>&1
 
+echo '====================== Deploying MetalLB ======================'
+echo 'Get the MetalLB manifest...'
+curl -sSLO https://raw.githubusercontent.com/metallb/metallb/v${METALLB_VER}/manifests/namespace.yaml
+curl -sSLO https://raw.githubusercontent.com/metallb/metallb/v${METALLB_VER}/manifests/metallb.yaml
+echo 'Deploying MetalLB...'
+kubectl create -f namespace.yaml > /dev/null 2>&1
+kubectl create -f metallb.yaml > /dev/null 2>&1
+curl -sSLO https://raw.githubusercontent.com/spiritsree/Vagrant-k8s-cluster/master/configs/metallb-config.yaml
+export IPF=$(echo ${IPADDR} | awk -F'.' '{ print $1 "." $2 "." $3 ".240" }')
+export IPL=$(echo ${IPADDR} | awk -F'.' '{ print $1 "." $2 "." $3 ".250" }')
+sed -i "s/IPF/${IPF}/g" metallb-config.yaml
+sed -i "s/IPL/${IPL}/g" metallb-config.yaml
+kubectl create -f metallb-config.yaml > /dev/null 2>&1
+
 echo '====================== END ======================'
 MASTERSCRIPT
 
@@ -294,7 +311,7 @@ Vagrant.configure("2") do |config|
     end
     master.vm.provision "shell" do |masterscript|
       masterscript.inline = $masterscript
-      masterscript.args = [NETWORKING_MODEL, METRICS_SERVER_VERSION]
+      masterscript.args = [NETWORKING_MODEL, METRICS_SERVER_VERSION, METALLB_VERSION]
     end
   end
 

--- a/configs/metallb-config.yaml
+++ b/configs/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - IPF-IPL


### PR DESCRIPTION
- Kubernetes - 1.20.15 (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md)
- Go - 1.15
- Docker - 19.03
- Crictl - 1.20.0 (https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.20.0)
- Metrics Server - 0.3.7
- Using Vagrant box memory as 1750 since Kubernetes 1.20 min requirement is 1700 MB
- Metallb setup and config for virtual LB for ingress setup (https://github.com/metallb/metallb)


```
[preflight] Running pre-flight checks
error execution phase preflight: [preflight] Some fatal errors occurred:
    [ERROR Mem]: the system RAM (992 MB) is less than the minimum 1700 MB
```