### PR TITLE
Updating all the tools and readme and fixing the related issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ Progress state: NS_ERROR_FAILURE
 
 Do a reinstall of Virtualbox and allow `Oracle` from System Preferences > Security & Privacy
 
+2. Using Virtualbox 6.1.28 onwards need more configuration for host-only network. Details [here](https://www.virtualbox.org/manual/ch06.html#network_hostonly) also the [Changelog](https://www.virtualbox.org/manual/UserManual.html#idp10525536)
+
+
 ## Versions
 
 Tested with below versions of the apps
 
 * Vagrant 2.2.17
-* VirtualBox 6.1.32
+* VirtualBox 6.1.26 (higher versions have issue with host-only network)
 * yq 4.6.1
 * ubuntu/xenial64 20210623.0.0

--- a/README.md
+++ b/README.md
@@ -83,5 +83,6 @@ Do a reinstall of Virtualbox and allow `Oracle` from System Preferences > Securi
 Tested with below versions of the apps
 
 * Vagrant 2.2.17
-* VirtualBox 6.1.22
+* VirtualBox 6.1.32
 * yq 4.6.1
+* ubuntu/xenial64 20210623.0.0

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ $ sh destroy.sh
 
 ## Supported Networking
 
-1. [flannel](https://github.com/coreos/flannel) (Default)
-1. [calico](https://www.projectcalico.org/)
-1. [canal](https://github.com/projectcalico/canal)
+1. [flannel](https://github.com/flannel-io/flannel) (Default)
+1. [calico](https://github.com/projectcalico/calico)
+1. [canal](https://projectcalico.docs.tigera.io/getting-started/kubernetes/flannel/flannel)
 1. [weavenet](https://www.weave.works/oss/net/)
 
 ## Other Networking
@@ -61,6 +61,7 @@ $ sh destroy.sh
 1. [Kubernetes](https://github.com/kubernetes/kubernetes)
 1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
 1. [MetalLB](https://github.com/metallb/metallb)
+1. [Calico Networking](https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises)
 
 ## Troubleshooting
 
@@ -80,12 +81,20 @@ Do a reinstall of Virtualbox and allow `Oracle` from System Preferences > Securi
 
 2. Using Virtualbox 6.1.28 onwards need more configuration for host-only network. Details [here](https://www.virtualbox.org/manual/ch06.html#network_hostonly) also the [Changelog](https://www.virtualbox.org/manual/UserManual.html#idp10525536)
 
+Create a file `/etc/vbox/networks.conf` with allowed IP ranges for Virtualbox.
+
+```
+$ cat /etc/vbox/networks.conf
+* 172.28.128.0/24
+* 192.168.56.0/24
+```
 
 ## Versions
 
 Tested with below versions of the apps
 
-* Vagrant 2.2.17
-* VirtualBox 6.1.26 (higher versions have issue with host-only network)
+* Vagrant 2.2.19
+* VirtualBox 6.1.32 (6.1.28 and higher versions have issue with host-only network. Pls check the troubleshooting section for details)
 * yq 4.6.1
-* ubuntu/xenial64 20210623.0.0
+* ubuntu/xenial64 (v20210623.0.0)
+* ubuntu/bionic64 (v20220317.0.0)

--- a/README.md
+++ b/README.md
@@ -53,15 +53,32 @@ $ sh destroy.sh
 1. [Cilium](https://github.com/cilium/cilium)
 1. [..and more](https://kubernetes.io/docs/concepts/cluster-administration/networking/)
 
+## Installations
+
+1. [Calico](https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises)
+1. [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/installation.md)
+1. [Critool](https://github.com/kubernetes-sigs/cri-tools#install)
+1. [Kubernetes install using Kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+1. [MetalLB](https://metallb.universe.tf/installation/)
+
 ## Reference
 
+1. [Calico Networking](https://www.tigera.io/tigera-products/calico/)
+1. [Containerd](https://github.com/containerd/containerd)
 1. [Critool](https://github.com/kubernetes-sigs/cri-tools)
 1. [Helm](https://github.com/helm/helm)
-1. [Kubeadm install](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
 1. [Kubernetes](https://github.com/kubernetes/kubernetes)
-1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
 1. [MetalLB](https://github.com/metallb/metallb)
-1. [Calico Networking](https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises)
+1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
+
+## Releases
+
+1. [Calico](https://github.com/projectcalico/calico/releases)
+1. [Containerd](https://github.com/containerd/containerd/releases)
+1. [Critool](https://github.com/kubernetes-sigs/cri-tools/releases)
+1. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md)
+1. [MetalLB](https://metallb.universe.tf/release-notes/)
+1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server/releases)
 
 ## Troubleshooting
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,7 +97,7 @@ tar zxf crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz
 
 echo '====================== Swap Off ======================'
-cat /proc/swaps
+[[ $(cat /proc/swaps | wc -l) -gt 1 ]] && cat /proc/swaps
 swapoff -a
 echo 'Swap is off...'
 [[ $(cat /etc/fstab | grep swap | wc -l) -gt 0 ]] && { sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab; }
@@ -105,7 +105,7 @@ echo 'Commented swap partition from fstab...'
 
 # Configure same cgroup for docker and kubernetes
 echo '====================== Configure cgroup to systemd ======================'
-echo -n 'Docker ' && docker info 2> /dev/null | grep -i cgroup
+echo -n 'Docker' && docker info 2> /dev/null | grep -i cgroup
 echo 'Changing Kubernetes cgroup type to systemd...'
 # Adding --authentication-token-webhook=true so that metrics-server can connect without any issues.
 # Adding --node-ip=VAGRANT_NODE_IP so the pods can be reached from other nodes/api

--- a/setup.sh
+++ b/setup.sh
@@ -157,7 +157,7 @@ main() {
         cp $HOME/.kube/config $HOME/.kube/config.bak
     fi
     echo "Getting the Kube Config from master..."
-    nc master.local 8888 | gunzip > ${KUBE_CONFIG}
+    nc master.local 8888 | base64 -d -o ${KUBE_CONFIG}
     if [[ ${yq_version} -lt 4 ]]; then
         cluster_server=$(${yq_bin} read ${KUBE_CONFIG} clusters[0].cluster.server)
         ${yq_bin} read ${KUBE_CONFIG} clusters[0].cluster.certificate-authority-data | base64 -D > ${CA_CERT_FILE}


### PR DESCRIPTION
- Readme update with new links and troubleshooting issues etc
- Kubernetes 1.21.11
- Crictl 1.21.0
- Adding Containerd (1.6.1)
- Metrics Server 0.6.1 and fix the yaml syntax
- MetalLB 0.12.1
- Ubuntu 18.04+ base image
- Support for Virtualbox 6.1.28+ with its IP change in host-only network. Check readme
- Increase VM memory to 1800MB
- Fix flannel, canal and calico urls and deploys