### PR TITLE
Kubernetes 1.23 and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ sh destroy.sh
 1. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md)
 1. [MetalLB](https://metallb.universe.tf/release-notes/)
 1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server/releases)
+1. [TOML CLI](https://github.com/gnprice/toml-cli/releases)
 
 ## Reference
 
@@ -113,6 +114,14 @@ Create a file `/etc/vbox/networks.conf` with allowed IP ranges for Virtualbox.
 $ cat /etc/vbox/networks.conf
 * 172.28.128.0/24
 * 192.168.56.0/24
+```
+
+## Running test
+
+From any node run the below to test container runtime
+
+```
+$ critest -parallel 10 -ginkgo.succinct
 ```
 
 ## Versions

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ $ sh destroy.sh
 
 1. [Calico](https://github.com/projectcalico/calico/releases)
 1. [Containerd](https://github.com/containerd/containerd/blob/main/RELEASES.md)
+1. [Containerd](https://containerd.io/releases/)
+1. [CRIO](https://github.com/cri-o/cri-o/releases)
 1. [Critool](https://github.com/kubernetes-sigs/cri-tools/releases)
 1. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md)
 1. [MetalLB](https://metallb.universe.tf/release-notes/)
@@ -114,6 +116,66 @@ Create a file `/etc/vbox/networks.conf` with allowed IP ranges for Virtualbox.
 $ cat /etc/vbox/networks.conf
 * 172.28.128.0/24
 * 192.168.56.0/24
+```
+
+## Installing Containerd
+
+* Install containerd
+
+```
+# curl -sSLO https://github.com/containerd/containerd/releases/download/v1.6.14/containerd-1.6.14-linux-amd64.tar.gz
+# tar xzvf containerd-1.6.14-linux-amd64.tar.gz -C /usr/local
+```
+
+* Install runc
+
+```
+# curl -sSLO https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64
+# install -m 755 runc.amd64 /usr/local/sbin/runc
+```
+
+* Install CNI plugins
+
+```
+# curl -sSLO https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+# mkdir -p /opt/cni/bin
+# tar xzvf cni-plugins-linux-amd64-v1.1.1.tgz -C /opt/cni/bin
+```
+
+* Configure containerd
+
+```
+# mkdir /etc/containerd
+# containerd config default | sudo tee /etc/containerd/config.toml
+# sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
+# curl -L https://raw.githubusercontent.com/containerd/containerd/main/containerd.service -o /etc/systemd/system/containerd.service
+# systemctl daemon-reload
+# systemctl enable --now containerd
+# systemctl status containerd
+```
+
+* Configure kubelet to use containerd as runtime
+
+Edit file `/var/lib/kubelet/kubeadm-flags.env` and add `--container-runtime=remote` and `--container-runtime-endpoint=unix:///run/containerd/containerd.sock`.
+
+`kubeadm` toold stores the CRI socket for each host as an annotation in the Node object. To change it you can execute the following command
+
+```
+$ kubectl edit node <node-name>
+```
+
+in the editor change the value of `kubeadm.alpha.kubernetes.io/cri-socket` from `/var/run/dockershim.sock` to CRI socket path of your choice, in this case (`unix:///run/containerd/containerd.sock`) and save the change.
+
+Restart kubelet
+
+```
+# systemctl restart kubelet
+```
+
+Check if the runtime is changed
+
+```
+# kubectl get nodes -o wide
 ```
 
 ## Running test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -307,7 +307,6 @@ nc ${MASTERIP} 8889 > kube_join
 echo '====================== Kubeadm Join cluster ======================'
 echo "Joining to master with IP ${MASTERIP}..."
 sh kube_join
-systemctl restart containerd
 
 echo '====================== Update Kube config ======================'
 echo 'Verifying if kube config is available..'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,13 +5,14 @@
 BOX_IMAGE = "ubuntu/bionic64"
 WORKER_COUNT = nil
 NETWORKING_TYPE = nil
-KUBERNETES_VERSION = '1.22.17'
-GO_VERSION = '1.16'
-DOCKER_VERSION = '19.03'
-CONTAINERD_VERSION = '1.6.14'
-CRICTL_VERSION = '1.22.1'
+KUBERNETES_VERSION = '1.23.15'
+GO_VERSION = '1.17'
+DOCKER_VERSION = '20.10'
+CONTAINERD_VERSION = '1.5.13'
+CRICTL_VERSION = '1.23.0'
 METRICS_SERVER_VERSION = '0.6.2'
 METALLB_VERSION = '0.13.7'
+TOML_CLI_VERSION = '0.2.3'
 
 if WORKER_COUNT.nil?
   NODE_COUNT = 2
@@ -32,28 +33,57 @@ export GO_VERSION=$2
 export DOCKER_VERSION=$3
 export CONTAINERD_VERSION=$4
 export CRICTL_VERSION=$5
+export TOML_VERSION=$6
 export DEBIAN_FRONTEND=noninteractive
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+
 echo '====================== Install mdns ======================'
 echo -n 'Install avahi-daemon and mdns: '
 apt-get update > /dev/null
 apt-get install -y avahi-daemon libnss-mdns > /dev/null
 [[ $? -eq 0 ]] && echo OK
 
-echo '====================== Adding apt-keys ======================'
+echo '=========== Adding apt-keys and install base pkgs ==============='
+mkdir /etc/apt/keyrings
 apt-get update > /dev/null && apt-get install -y apt-transport-https ca-certificates curl jq software-properties-common libseccomp2 > /dev/null
 echo -n 'Add docker apt-key: '
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 echo -n 'Add docker apt-repository: '
 add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" > /dev/null
 [[ $? -eq 0 ]] && echo OK || { add-apt-repository -r "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" > /dev/null; exit 1; }
-
 echo -n 'Add google cloud apt-key: '
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 echo -n 'Add kubernetes apt-repository: '
-add-apt-repository "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /dev/null
-[[ $? -eq 0 ]] && echo OK || { add-apt-repository -r "deb https://apt.kubernetes.io/ kubernetes-xenial main"; echo "Check https://packages.cloud.google.com/apt/dists"; exit 1; }
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+[[ $? -eq 0 ]] && echo OK || { echo "Check https://packages.cloud.google.com/apt/dists"; exit 1; }
 apt-get update > /dev/null
+curl -sSLO https://github.com/gnprice/toml-cli/releases/download/v${TOML_VERSION}/toml-${TOML_VERSION}-x86_64-linux.tar.gz
+tar xzf toml-${TOML_VERSION}-x86_64-linux.tar.gz
+mv toml-${TOML_VERSION}-x86_64-linux/toml /usr/local/bin
+
+echo '====================== Traffic through iptables ======================'
+echo -n 'Forwarding IPv4 and letting iptables see bridged traffic..'
+echo "overlay" > /etc/modules-load.d/k8s.conf
+echo "br_netfilter" >> /etc/modules-load.d/k8s.conf
+modprobe overlay
+modprobe br_netfilter
+echo "net.bridge.bridge-nf-call-iptables  = 1" > /etc/sysctl.d/k8s.conf
+echo "net.bridge.bridge-nf-call-ip6tables = 1" >> /etc/sysctl.d/k8s.conf
+echo "net.ipv4.ip_forward                 = 1" >> /etc/sysctl.d/k8s.conf
+sysctl --system > /dev/null
+[[ $? -eq 0 ]] && echo OK
+
+echo '====================== Install and Setup Go ======================'
+echo -n 'Download and install go: '
+curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz 2> /dev/null && \
+tar -xzf go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local
+[[ $? -eq 0 ]] && { echo OK; echo 'export GOROOT=/usr/local/go' >> /etc/profile; echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/profile; source /etc/profile; }
+mkdir -p /go/{bin,src}
+export GOPATH=/go
+echo "export GOPATH=/go" >> /etc/profile
+export PATH=$PATH:$GOPATH/bin
+echo "export PATH=$PATH:$GOPATH/bin" >> /etc/profile
+
 echo '====================== Install Docker ======================'
 echo -n 'Install Docker-CE: '
 docker_image_version=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{print $3}')
@@ -69,25 +99,12 @@ echo -n 'Install Containerd: '
 curl -sSLO https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz 2> /dev/null && \
 tar --no-overwrite-dir -C / -xzf cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
 [[ $? -eq 0 ]] && echo OK
+# Enable CRI plugin in containerd
+if [[ -f /etc/containerd/config.toml ]]; then
+  toml set /etc/containerd/config.toml disabled_plugins "$(toml get  /etc/containerd/config.toml disabled_plugins | jq -c 'del(.[] | select(. == "cri"))')" | sed 's/\\//g' | sed 's/"\[/\[/' | sed 's/\]"/\]/' > config.toml
+  mv config.toml /etc/containerd/config.toml
+fi
 systemctl start containerd
-
-echo '====================== Install Kubernetes ======================'
-echo -n 'Install Kubernetes: '
-apt-get install -y kubeadm=$(apt-cache madison kubeadm | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') \
-kubectl=$(apt-cache madison kubectl | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') \
-kubelet=$(apt-cache madison kubelet | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') > /dev/null
-[[ $? -eq 0 ]] && echo OK
-
-echo '====================== Install and Setup Go ======================'
-echo -n 'Download and install go: '
-curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz 2> /dev/null && \
-tar -xzf go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local
-[[ $? -eq 0 ]] && { echo OK; echo 'export GOROOT=/usr/local/go' >> /etc/profile; echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/profile; source /etc/profile; }
-mkdir -p /go/{bin,src}
-export GOPATH=/go
-echo "export GOPATH=/go" >> /etc/profile
-export PATH=$PATH:$GOPATH/bin
-echo "export PATH=$PATH:$GOPATH/bin" >> /etc/profile
 
 echo '====================== Install crictl ======================'
 echo -n 'Install crictl: '
@@ -95,6 +112,7 @@ curl -sSLO https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRI
 tar zxf crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
 [[ $? -eq 0 ]] && echo OK
 rm -f crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz
+go install github.com/onsi/ginkgo/ginkgo@latest > /dev/null 2> /dev/null
 
 echo '====================== Swap Off ======================'
 [[ $(cat /proc/swaps | wc -l) -gt 1 ]] && cat /proc/swaps
@@ -103,13 +121,20 @@ echo 'Swap is off...'
 [[ $(cat /etc/fstab | grep swap | wc -l) -gt 0 ]] && { sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab; }
 echo 'Commented swap partition from fstab...'
 
-# Configure same cgroup for docker and kubernetes
+echo '====================== Install Kubernetes ======================'
+echo -n 'Install Kubernetes: '
+apt-get install -y kubeadm=$(apt-cache madison kubeadm | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') \
+kubectl=$(apt-cache madison kubectl | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') \
+kubelet=$(apt-cache madison kubelet | grep ${KUBE_VERSION} |  head -1 | awk '{print $3}') > /dev/null
+[[ $? -eq 0 ]] && echo OK
+
 echo '====================== Configure cgroup to systemd ======================'
+# Configure same cgroup for docker and kubernetes
 echo -n 'Docker' && docker info 2> /dev/null | grep -i cgroup
 echo 'Changing Kubernetes cgroup type to systemd...'
 # Adding --authentication-token-webhook=true so that metrics-server can connect without any issues.
 # Adding --node-ip=VAGRANT_NODE_IP so the pods can be reached from other nodes/api
-node_if=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }')
+node_if=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }' | tr -d ':')
 node_ip=$(ifconfig ${node_if} | grep -E 'Mask|netmask' | awk '{ print $2 }' | cut -d: -f2)
 if [[ $(cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf | grep 'authentication-token-webhook=true' | wc -l) -eq 0 ]]; then
   E_ARG_PARAM="--cgroup-driver=systemd --authentication-token-webhook=true --node-ip=${node_ip}"
@@ -143,12 +168,10 @@ echo -n 'Docker ' && docker info 2> /dev/null | grep -i cgroup
 echo '====================== Net Info ======================'
 echo -e "IP Link ...... \n $(ip link)"
 echo -e "Product UUID ...... \n $(cat /sys/class/dmi/id/product_uuid)"
-
 SCRIPT
 
 # Master Script to initialize and setup Kubernetes Master.
 $masterscript = <<-'MASTERSCRIPT'
-
 export NET_INTERFACE=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }' | tr -d ':')
 export IPADDR=$(ifconfig ${NET_INTERFACE} | grep -E 'Mask|netmask' | awk '{ print $2 }' | cut -d: -f2)
 export NODENAME=$(hostname -s)
@@ -162,14 +185,9 @@ echo "$IPADDR  $NODENAME.local" >> /etc/hosts
 
 echo '====================== Initialize Kubeadm ======================'
 kube_version=$(kubectl version --client --short -o json | jq -r '"stable-" + .clientVersion.major + "." + .clientVersion.minor')
-kubeadm init --pod-network-cidr=10.244.0.0/16 --apiserver-advertise-address=$IPADDR --kubernetes-version=${kube_version} | tee kubeinit.out
+kubeadm init --pod-network-cidr=10.244.0.0/16 --service-cidr=10.96.0.0/16 --apiserver-advertise-address=$IPADDR --kubernetes-version=${kube_version} | tee kubeinit.out
 echo "$(cat kubeinit.out | sed ':a;N;$!ba;s/\\\n/ /g' | grep -e '^[ ]*kubeadm join' | sed -e 's/^[ \t]*//')" > /opt/join.cmd
 export KUBECONFIG=/etc/kubernetes/admin.conf
-
-echo '====================== Traffic through iptables ======================'
-echo 'IPv4 trafic to pass through the iptables chain..'
-echo 'Setting net.bridge.bridge-nf-call-iptables to 1..'
-sysctl net.bridge.bridge-nf-call-iptables=1
 
 echo '====================== Setup admin cred ======================'
 echo 'Copying credentials to $HOME/.kube/config ...'
@@ -261,7 +279,7 @@ MASTERSCRIPT
 
 # Worker Script to initialize and join the Master to form a cluster.
 $workerscript = <<-'WORKERSCRIPT'
-export NET_INTERFACE=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }')
+export NET_INTERFACE=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }' | tr -d ':')
 export IPADDR=$(ifconfig ${NET_INTERFACE} | grep -e 'Mask|netmask' | awk '{ print $2 }' | cut -d: -f2)
 export NODENAME=$(hostname -s)
 export CONFIG_READY=0
@@ -314,7 +332,7 @@ Vagrant.configure("2") do |config|
     master.vm.network "private_network", type: "dhcp"
     master.vm.provision "shell" do |script|
       script.inline = $script
-      script.args = [KUBERNETES_VERSION, GO_VERSION, DOCKER_VERSION, CONTAINERD_VERSION, CRICTL_VERSION]
+      script.args = [KUBERNETES_VERSION, GO_VERSION, DOCKER_VERSION, CONTAINERD_VERSION, CRICTL_VERSION, TOML_CLI_VERSION]
     end
     master.vm.provision "shell" do |masterscript|
       masterscript.inline = $masterscript
@@ -329,7 +347,7 @@ Vagrant.configure("2") do |config|
       node.vm.network "private_network", type: "dhcp"
       node.vm.provision "shell" do |script|
        script.inline = $script
-       script.args = [KUBERNETES_VERSION, GO_VERSION, DOCKER_VERSION, CONTAINERD_VERSION, CRICTL_VERSION]
+       script.args = [KUBERNETES_VERSION, GO_VERSION, DOCKER_VERSION, CONTAINERD_VERSION, CRICTL_VERSION, TOML_CLI_VERSION]
       end
       node.vm.provision "shell", inline: $workerscript
     end


### PR DESCRIPTION
- Readme update with more links and Containerd installing the hard way
- App Version list

  * Kubernetes - [1.23.15](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md)
  * Go - 1.17
  * Docker - 20.10
  * Containerd - [1.5.x](https://github.com/containerd/containerd/blob/main/RELEASES.md)
  * Crictl - [1.23.0](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.23.0)
  * MetalLB - [0.13.7](https://metallb.universe.tf/release-notes/)
  * Metrics Server - 0.6.2
  * MetalLB - 0.13.7
  * Toml Client - 0.2.3 (Adding toml client to edit toml files)

- Scripting re-arrange
- Updated sysctl as per https://kubernetes.io/docs/setup/production-environment/container-runtimes/
- Fix interface name issue started from ubuntu update (bionic)
- Added explicit service-cidr while initialising Kubernetes
- Containerd downgraded to 1.5 since cri-tool failing due to the below error
- Installing critest
- Installing Containerd from apt rather than manual hard way

```
incompatible CNI versions; config is "1.0.0", plugin supports ["0.1.0" "0.2.0" "0.3.0" "0.3.1" "0.4.0"]
```

Tested with following

* MacOS Big Sur
* Vagrant 2.3.4
* VirtualBox 7.0.4 (AMD64)

Ran critest in nodes

```
# critest -parallel 10 -ginkgo.succinct

~~ truncated ~~

• [SLOW TEST:29.924 seconds]
[k8s.io] Streaming runtime should support streaming interfaces runtime should support portforward in host network 
/tmp/tmp.zisjPmozyh/cri-tools/pkg/validate/streaming_linux.go:48
------------------------------
 SUCCESS! 2m25.103373803s 

Ginkgo ran 1 suite in 2m25.267196438s
Test Suite Passed
PASS
```