### PR TITLE
Fixing interface name issue while setting up the workers and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,33 @@ $ sh destroy.sh
 1. [Cilium](https://github.com/cilium/cilium)
 1. [..and more](https://kubernetes.io/docs/concepts/cluster-administration/networking/)
 
+## Container Runtimes
+
+1. [Container Runtimes](https://kubernetes.io/docs/setup/production-environment/container-runtimes/)
+1. [Containerd](https://github.com/containerd/containerd)
+1. [CRI-O](https://github.com/cri-o/cri-o)
+
 ## Installations
 
 1. [Calico](https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises)
 1. [Containerd](https://github.com/containerd/containerd/blob/main/docs/cri/installation.md)
+1. [CRI-O](https://github.com/cri-o/cri-o/blob/main/install.md)
 1. [Critool](https://github.com/kubernetes-sigs/cri-tools#install)
 1. [Kubernetes install using Kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
 1. [MetalLB](https://metallb.universe.tf/installation/)
 
+## Releases
+
+1. [Calico](https://github.com/projectcalico/calico/releases)
+1. [Containerd](https://github.com/containerd/containerd/blob/main/RELEASES.md)
+1. [Critool](https://github.com/kubernetes-sigs/cri-tools/releases)
+1. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md)
+1. [MetalLB](https://metallb.universe.tf/release-notes/)
+1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server/releases)
+
 ## Reference
 
 1. [Calico Networking](https://www.tigera.io/tigera-products/calico/)
-1. [Containerd](https://github.com/containerd/containerd)
 1. [Critool](https://github.com/kubernetes-sigs/cri-tools)
 1. [Helm](https://github.com/helm/helm)
 1. [Kubernetes](https://github.com/kubernetes/kubernetes)
@@ -73,15 +88,6 @@ $ sh destroy.sh
 1. [Vagrant](https://www.vagrantup.com)
 1. [Vagrant Install](https://developer.hashicorp.com/vagrant/downloads)
 1. [VirtualBox](https://www.virtualbox.org/wiki/Changelog)
-
-## Releases
-
-1. [Calico](https://github.com/projectcalico/calico/releases)
-1. [Containerd](https://github.com/containerd/containerd/releases)
-1. [Critool](https://github.com/kubernetes-sigs/cri-tools/releases)
-1. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md)
-1. [MetalLB](https://metallb.universe.tf/release-notes/)
-1. [Metrics Server](https://github.com/kubernetes-sigs/metrics-server/releases)
 
 ## Troubleshooting
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,7 +109,7 @@ echo -n 'Docker' && docker info 2> /dev/null | grep -i cgroup
 echo 'Changing Kubernetes cgroup type to systemd...'
 # Adding --authentication-token-webhook=true so that metrics-server can connect without any issues.
 # Adding --node-ip=VAGRANT_NODE_IP so the pods can be reached from other nodes/api
-node_if=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }')
+node_if=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }' | tr -d ':')
 node_ip=$(ifconfig ${node_if} | grep -E 'Mask|netmask' | awk '{ print $2 }' | cut -d: -f2)
 if [[ $(cat /etc/systemd/system/kubelet.service.d/10-kubeadm.conf | grep 'authentication-token-webhook=true' | wc -l) -eq 0 ]]; then
   E_ARG_PARAM="--cgroup-driver=systemd --authentication-token-webhook=true --node-ip=${node_ip}"
@@ -261,7 +261,7 @@ MASTERSCRIPT
 
 # Worker Script to initialize and join the Master to form a cluster.
 $workerscript = <<-'WORKERSCRIPT'
-export NET_INTERFACE=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }')
+export NET_INTERFACE=$(ifconfig | grep -B2 -E '172.28.128|192.168.56' | grep enp0 | awk '{ print $1 }' | tr -d ':')
 export IPADDR=$(ifconfig ${NET_INTERFACE} | grep -e 'Mask|netmask' | awk '{ print $2 }' | cut -d: -f2)
 export NODENAME=$(hostname -s)
 export CONFIG_READY=0


### PR DESCRIPTION
- Readme update
- From ubuntu focal interface name has got `:` at the end which is causing issue with setting kubelet with nodeIP. Fixing the same